### PR TITLE
Drop uuid dependency and use random string for ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "preact-render-spy": "^1.0.0-rc.8",
     "prettier": "^1.7.0",
     "sinon": "^1.17.3",
-    "uuid": "^3.0.1",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.8.2"
   },

--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -1,14 +1,10 @@
 // noinspection ES6UnusedImports
 import { h } from 'preact';
-
-const randomId = () =>
-  Math.random()
-    .toString(36)
-    .substr(2, 9);
+import uid from './uid';
 
 const Wrap = props => {
-  let idClip = randomId();
-  let idGradient = randomId();
+  let idClip = uid();
+  let idGradient = uid();
 
   return (
     <svg

--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -1,10 +1,14 @@
 // noinspection ES6UnusedImports
 import { h } from 'preact';
-import uuid from 'uuid';
+
+const randomId = () =>
+  Math.random()
+    .toString(36)
+    .substr(2, 9);
 
 const Wrap = props => {
-  let idClip = uuid.v1();
-  let idGradient = uuid.v1();
+  let idClip = randomId();
+  let idGradient = randomId();
 
   return (
     <svg

--- a/src/uid.js
+++ b/src/uid.js
@@ -1,0 +1,4 @@
+export default () =>
+  Math.random()
+    .toString(36)
+    .substring(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,7 +4732,7 @@ uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1:
+uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
I'd like to remove the `uuid` dependency. It adds about 1kb gzip to the package, but we can generate unique enough strings with `Math.random`.

If you would like to keep the dependency on `uuid`, then it should be specified under `dependencies` in `package.json` instead of `devDependencies`.